### PR TITLE
 Fix: on order modification configuration is ignored

### DIFF
--- a/core/triggers/interface_90_modECommerceng_ECommerceng.class.php
+++ b/core/triggers/interface_90_modECommerceng_ECommerceng.class.php
@@ -819,6 +819,11 @@ class InterfaceECommerceng
                     dol_syslog("Triggers was ran from a create/update to sync from ecommerce to dolibarr, so we won't run code to sync from dolibarr to ecommerce");
                     continue;
                 }
+		    
+		if (empty($site->parameters['realtime_dtoe']['order'])) {
+                    dol_syslog("Triggers disabled from the config of the module");
+                    continue;
+                }    
 
             	try
             	{

--- a/core/triggers/interface_90_modECommerceng_ECommerceng.class.php
+++ b/core/triggers/interface_90_modECommerceng_ECommerceng.class.php
@@ -823,7 +823,7 @@ class InterfaceECommerceng
 		if (empty($site->parameters['realtime_dtoe']['order'])) {
                     dol_syslog("Triggers disabled from the config of the module");
                     continue;
-                }    
+                }
 
             	try
             	{


### PR DESCRIPTION
Add check of configuration before doing realtime update for order when shipment is validated related to #6
Also temporary fix for issue #9 (that works when realtime update is not used)