### PR TITLE
Fix update product with UGS code and variations fail 

### DIFF
--- a/class/business/eCommerceSynchro.class.php
+++ b/class/business/eCommerceSynchro.class.php
@@ -1676,16 +1676,13 @@ class eCommerceSynchro
                             $refExists = $dBProduct->fetch('', $ref);
                             if ($refExists > 0) {
                                 $synchExists = $this->eCommerceProduct->fetchByProductId($dBProduct->id, $this->eCommerceSite->id);
-                                if ($synchExists > 0 && $this->eCommerceProduct->remote_id != $productArray['remote_id']) {
-					$synchExists = $this->eCommerceProduct->fetchByProductId($dBProduct->id, $this->eCommerceSite->id);
-					$productVariations = explode('|', $productArray['remote_id']);
-					if ($synchExists > 0 && !in_array($this->eCommerceProduct->remote_id, $productVariations) ) {
-					    dol_syslog('Error: Remote product (ref: ' . $ref . ', remote id: ' . $productArray['remote_id'] . ') already linked with other remote product (remote id: ' . $this->eCommerceProduct->remote_id . ")", LOG_DEBUG);
-					    $error++;
-					    $this->errors[] = $this->langs->trans('ECommerceSynchProductError') . ' Ref: ' . $productArray['ref'] . ', Nom: ' . $productArray['label'] . ', remote ID: ' . $productArray['remote_id'];
-					    $this->errors[] = $this->langs->trans('ECommerceErrorProductAlreadyLinkedWithRemoteProduct', $this->eCommerceProduct->remote_id);
-					    break;
-					}
+                                $productVariations = explode('|', $productArray['remote_id']);
+                                if ($synchExists > 0 && !in_array($this->eCommerceProduct->remote_id, $productVariations) ) {
+                                    dol_syslog('Error: Remote product (ref: ' . $ref . ', remote id: ' . $productArray['remote_id'] . ') already linked with other remote product (remote id: ' . $this->eCommerceProduct->remote_id . ")", LOG_DEBUG);
+                                    $error++;
+                                    $this->errors[] = $this->langs->trans('ECommerceSynchProductError') . ' Ref: ' . $productArray['ref'] . ', Nom: ' . $productArray['label'] . ', remote ID: ' . $productArray['remote_id'];
+                                    $this->errors[] = $this->langs->trans('ECommerceErrorProductAlreadyLinkedWithRemoteProduct', $this->eCommerceProduct->remote_id);
+                                    break;
                                 }
                             }
                         } else {

--- a/class/business/eCommerceSynchro.class.php
+++ b/class/business/eCommerceSynchro.class.php
@@ -1677,11 +1677,15 @@ class eCommerceSynchro
                             if ($refExists > 0) {
                                 $synchExists = $this->eCommerceProduct->fetchByProductId($dBProduct->id, $this->eCommerceSite->id);
                                 if ($synchExists > 0 && $this->eCommerceProduct->remote_id != $productArray['remote_id']) {
-                                    dol_syslog('Error: Remote product (ref: '.$ref.', remote id: '.$productArray['remote_id'].') already linked with other remote product (remote id: '.$this->eCommerceProduct->remote_id.")", LOG_DEBUG);
-                                    $error++;
-                                    $this->errors[] = $this->langs->trans('ECommerceSynchProductError') . ' Ref: ' . $productArray['ref'] . ', Nom: ' . $productArray['label'] . ', remote ID: ' . $productArray['remote_id'];
-                                    $this->errors[] = $this->langs->trans('ECommerceErrorProductAlreadyLinkedWithRemoteProduct', $this->eCommerceProduct->remote_id);
-                                    break;
+					$synchExists = $this->eCommerceProduct->fetchByProductId($dBProduct->id, $this->eCommerceSite->id);
+					$productVariations = explode('|', $productArray['remote_id']);
+					if ($synchExists > 0 && !in_array($this->eCommerceProduct->remote_id, $productVariations) ) {
+					    dol_syslog('Error: Remote product (ref: ' . $ref . ', remote id: ' . $productArray['remote_id'] . ') already linked with other remote product (remote id: ' . $this->eCommerceProduct->remote_id . ")", LOG_DEBUG);
+					    $error++;
+					    $this->errors[] = $this->langs->trans('ECommerceSynchProductError') . ' Ref: ' . $productArray['ref'] . ', Nom: ' . $productArray['label'] . ', remote ID: ' . $productArray['remote_id'];
+					    $this->errors[] = $this->langs->trans('ECommerceErrorProductAlreadyLinkedWithRemoteProduct', $this->eCommerceProduct->remote_id);
+					    break;
+					}
                                 }
                             }
                         } else {

--- a/class/business/eCommerceSynchro.class.php
+++ b/class/business/eCommerceSynchro.class.php
@@ -1677,13 +1677,17 @@ class eCommerceSynchro
                             if ($refExists > 0) {
                                 $synchExists = $this->eCommerceProduct->fetchByProductId($dBProduct->id, $this->eCommerceSite->id);
                                 $productVariations = explode('|', $productArray['remote_id']);
-                                if ($synchExists > 0 && !in_array($this->eCommerceProduct->remote_id, $productVariations) ) {
+                                if ($synchExists > 0 && 
+                                        !in_array($this->eCommerceProduct->remote_id, $productVariations)  // Is variable product but without UGS for this variation
+                                        && 
+                                        $this->eCommerceProduct->remote_id !== $productArray['remote_id'] // Is variable product variations with an UGS for this variation
+                                        ) {
                                     dol_syslog('Error: Remote product (ref: ' . $ref . ', remote id: ' . $productArray['remote_id'] . ') already linked with other remote product (remote id: ' . $this->eCommerceProduct->remote_id . ")", LOG_DEBUG);
                                     $error++;
                                     $this->errors[] = $this->langs->trans('ECommerceSynchProductError') . ' Ref: ' . $productArray['ref'] . ', Nom: ' . $productArray['label'] . ', remote ID: ' . $productArray['remote_id'];
                                     $this->errors[] = $this->langs->trans('ECommerceErrorProductAlreadyLinkedWithRemoteProduct', $this->eCommerceProduct->remote_id);
                                     break;
-                                }
+                                }                                  
                             }
                         } else {
                             $dBProduct->id = 0;


### PR DESCRIPTION
ISSUE: An error with message ECommerceErrorProductAlreadyLinkedWithRemoteProduct 
is triggered because product ID not match the variation remote ID.
(when product has an UGS and variations has no UGS and ref synch direction is ecommerce to Dolibarr)