### PR TITLE
FIX: oauth: bad token redirection

### DIFF
--- a/admin/eCommerceSetup.php
+++ b/admin/eCommerceSetup.php
@@ -834,7 +834,7 @@ if ($ecommerceId > 0) {
         } catch(Exception $e) {}
         $ecommerceOAuthGenerateToken = (!empty($ecommerceOAuthId) && !empty($ecommerceOAuthSecret) || is_object($ecommerceOAuthTokenObj));
 
-        $ecommerceOAuthBackToUri = urlencode(dol_buildpath('/ecommerceng/admin/eCommerceSetup.php', 2).'?ecommerce_id='.$ecommerceId);
+        $ecommerceOAuthBackToUri = urlencode(dol_buildpath('/ecommerceng/admin/eCommerceSetup.php', 1).'?ecommerce_id='.$ecommerceId);
 
         if (is_object($ecommerceOAuthTokenObj)) {
             $ecommerceOAuthTokenExpired = ($ecommerceOAuthTokenObj->getEndOfLife() !== $ecommerceOAuthTokenObj::EOL_NEVER_EXPIRES && $ecommerceOAuthTokenObj->getEndOfLife() !== $ecommerceOAuthTokenObj::EOL_UNKNOWN && time() > ($ecommerceOAuthTokenObj->getEndOfLife() - 30));


### PR DESCRIPTION
Par rapport au script `/core/modules/oauth/wordpress_oauthcallback.php` du module : `GETPOST()` a une protection spéciale pour les paramètres `backtopage`, `backtolist` ou `backtourl`, qui retire le protocole de l'URL passée en paramètre pour éviter les redirections vers des domaines externes.

Du coup la redirection voulue `header('Location: https://tartempion.example.com/custom/ecommerceng/admin/eCommerceSetup.php')` devient `header('Location: tartempion.example.com/custom/ecommerceng/admin/eCommerceSetup.php')`, ce qui mène à une 404 sur `https://tartempion.example.com/custom/ecommerceng/core/modules/oauth/tartempion.example.com/custom/ecommerceng/admin/eCommerceSetup.php` => Il faut donc passer l'URL absolue sans le domaine.