### PR TITLE
Update eCommerceSynchro.class.php

### DIFF
--- a/class/business/eCommerceSynchro.class.php
+++ b/class/business/eCommerceSynchro.class.php
@@ -1270,7 +1270,7 @@ class eCommerceSynchro
                 {
                     //eCommerce create
                     $this->eCommerceSocpeople->fk_site = $this->eCommerceSite->id;
-                    $this->eCommerceSocpeople->remote_id = isset($socpeopleArray['remote_id']) ? $socpeopleArray['remote_id'] : 'none-'.$dBContact->id;
+                    $this->eCommerceSocpeople->remote_id = !empty($socpeopleArray['remote_id']) ? $socpeopleArray['remote_id'] : 'none-'.$dBContact->id;
                     $this->eCommerceSocpeople->type = $socpeopleArray['type'];
                     if ($this->eCommerceSocpeople->create($this->user) < 0)
                     {


### PR DESCRIPTION
Here is my understanding:
At line 1273, if `$socpeopleArray['remote_id']` is empty (equal to "") then `isset()` returns True and we'll set `$this->eCommerceSocpeople->remote_id=""`. 
Therefore we'll add a new line to `llx_ecommerceng_socpeople` with `fk_site=1` and `remote_id=""`. 
The second time we've got this type of contact, we'll try to add a new line with `fk_site=1` and `remote_id=""` ; resulting in `Error Duplicate Entry '1--1' for key 'uk_ecommerceng_socpeople_fk_site_remote_id`. 
Replacing `isset()` by `!empty()` seems to solve the issue.