### PR TITLE
Repair PHP Fatal error

### DIFF
--- a/class/data/woocommerce/eCommerceRemoteAccessWoocommerce.class.php
+++ b/class/data/woocommerce/eCommerceRemoteAccessWoocommerce.class.php
@@ -3467,7 +3467,7 @@ class eCommerceRemoteAccessWoocommerce
                 ' - Request:' . json_encode($fault->getRequest()) . ' - Response:' . json_encode($fault->getResponse()), LOG_ERR);
             return false;
         }
-        $results = isset($results->products) ? $results->products : is_array($results) ? $results : [];
+          $results = ((isset($results->products) ? $results->products : is_array($results) ) ? $results : []);
 
 		$remote_id = '';
 		$remote_url = '';


### PR DESCRIPTION
Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)