### PR TITLE
use ref if no match in ecommerce_product

### DIFF
--- a/class/data/woocommerce/eCommerceRemoteAccessWoocommerce.class.php
+++ b/class/data/woocommerce/eCommerceRemoteAccessWoocommerce.class.php
@@ -920,12 +920,19 @@ class eCommerceRemoteAccessWoocommerce
 			foreach ($page as $product) {
 				// Don't synchronize the variation parent
 				if (empty($product->variations) || !empty($product->parent_id)) {
-					$data = $this->convertProductDataIntoProcessedData($product);
-					if (!is_array($data)) {
-						$this->errors = array_merge(array($langs->trans('ECommerceErrorWhenConvertProductData', $product->id)), $this->errors);
-						return false;
+					$res = 0;
+					if (!empty($product->sku)) {
+						$is_product = new Product($this->db);
+						$res = $is_product->fetch('', $product->sku);
 					}
-					$products[] = $data;
+					if ($res <= 0){
+						$data = $this->convertProductDataIntoProcessedData($product);
+						if (!is_array($data)) {
+							$this->errors = array_merge(array($langs->trans('ECommerceErrorWhenConvertProductData', $product->id)), $this->errors);
+							return false;
+						}
+						$products[] = $data;
+					}
 				}
 
 				// Synchronize all the variations of the product if only the parent is provided


### PR DESCRIPTION
When we use WPML in woocommerce, products can’t be associated to lines in Dolibarr orders because the llx_ecommerce_product table states that there is only one wordpress post per SKU — and WPML generates one post for each language. This checks the ref if the product hasn’t been found (or couldn’t be created) in the matching table, so we can still have an order with the products instead of free lines.