### PR TITLE
php8: don't call non-static methods

### DIFF
--- a/class/business/eCommerceSynchro.class.php
+++ b/class/business/eCommerceSynchro.class.php
@@ -623,7 +623,8 @@ class eCommerceSynchro
 			$tmp = $this->eCommerceRemoteAccess->getRemoteCategoryTree();
 			if (is_array($tmp)) {
 				$resanswer = array();
-				eCommerceCategory::cuttingCategoryTreeFromMagentoToDolibarrNew($tmp, $resanswer);
+				$eCat = new eCommerceCategory($db);
+				$eCat->cuttingCategoryTreeFromMagentoToDolibarrNew($tmp, $resanswer);
 
 				$this->initECommerceCategory(); // Initialise 2 properties eCommerceCategory and eCommerceMotherCategory
 


### PR DESCRIPTION
The ability to call non-static methods statically has been removed. Thus is_callable() will fail when checking for a non-static method with a classname (must check with an object instance).

There are other places where this happens:

![image](https://user-images.githubusercontent.com/45109319/234960075-76459105-5508-4151-b4da-b101f302ed83.png)
