### PR TITLE
Fix sanitization and settings saving issues with Dolibarr 20

### DIFF
--- a/admin/order.php
+++ b/admin/order.php
@@ -171,7 +171,7 @@ if ($action == 'set_options') {
 	$object->parameters['realtime_dtoe']['order'] = GETPOST('realtime_dtoe_order', 'int') ? 1 : 0;
 	$object->parameters['order_actions']['create_invoice'] = GETPOST('create_invoice', 'int') ? 1 : 0;
 	$object->parameters['order_actions']['create_invoice_type'] = GETPOST('create_invoice_type', 'int');
-	$object->parameters['order_actions']['create_invoice_deposit_type'] = GETPOST('create_invoice_deposit_type', 'az09');
+	$object->parameters['order_actions']['create_invoice_deposit_type'] = GETPOST('create_invoice_deposit_type', 'aZ09');
 	$object->parameters['order_actions']['create_invoice_deposit_value'] = GETPOST('create_invoice_deposit_value', 'int');
 	$object->parameters['order_actions']['create_invoice_if_amount_0'] = GETPOST('create_invoice_if_amount_0', 'int') ? 1 : 0;
 	$object->parameters['order_actions']['send_invoice_by_mail'] = GETPOST('send_invoice_by_mail', 'int') ? 1 : 0;
@@ -180,7 +180,7 @@ if ($action == 'set_options') {
 	$object->parameters['order_first_date_etod'] = GETPOST('order_first_date_etod', 'alphanohtml') ? dol_mktime(0, 0, 0, GETPOST('order_first_date_etodmonth', 'int'), GETPOST('order_first_date_etodday', 'int'), GETPOST('order_first_date_etodyear', 'int')) : null;
 	$object->parameters['order_actions']['fee_line_as_item_line'] = GETPOST('fee_line_as_item_line', 'int') ? 1 : 0;
 	$object->parameters['order_metadata_product_lines_to_description_etod'] = GETPOST('order_metadata_product_lines_to_description_etod', 'int') ? 1 : 0;
-	$object->parameters['order_filter_mode_metadata_product_lines_to_description_etod'] = GETPOST('order_filter_mode_metadata_product_lines_to_description_etod', 'az09');
+	$object->parameters['order_filter_mode_metadata_product_lines_to_description_etod'] = GETPOST('order_filter_mode_metadata_product_lines_to_description_etod', 'aZ09');
 	$object->parameters['order_filter_keys_metadata_product_lines_to_description_etod'] = GETPOST('order_filter_keys_metadata_product_lines_to_description_etod', 'alphanohtml');
 	$object->parameters['order_actions']['order_note_into_public_note'] = GETPOST('order_note_into_public_note', 'int') ? 1 : 0;
 

--- a/admin/product.php
+++ b/admin/product.php
@@ -139,7 +139,7 @@ if ($action == 'set_options') {
 	$object->fk_cat_product = GETPOST('fk_cat_product', 'int');
 	$object->fk_cat_product = $object->fk_cat_product > 0 ? $object->fk_cat_product : 0;
 	$object->parameters['realtime_dtoe']['product'] = GETPOST('realtime_dtoe_product', 'int') ? 1 : 0;
-	$object->ecommerce_price_type = GETPOST('base_price_type', 'az09');
+	$object->ecommerce_price_type = GETPOST('base_price_type', 'aZ09');
 	$object->parameters['fee_service'] = GETPOST('fee_service', 'int');
 	$object->parameters['fee_service'] = $object->parameters['fee_service'] > 0 ? $object->parameters['fee_service'] : 0;
 	$object->parameters['shipping_service'] = GETPOST('shipping_service', 'int');
@@ -150,10 +150,10 @@ if ($action == 'set_options') {
 	$object->parameters['pw_gift_cards_service'] = $object->parameters['pw_gift_cards_service'] > 0 ? $object->parameters['pw_gift_cards_service'] : 0;
 	$object->parameters['acfw_store_credits_service'] = GETPOST('acfw_store_credits_service', 'int');
 	$object->parameters['acfw_store_credits_service'] = $object->parameters['acfw_store_credits_service'] > 0 ? $object->parameters['acfw_store_credits_service'] : 0;
-	$object->parameters['product_synch_price'] = GETPOST('product_synch_price', 'az09');
+	$object->parameters['product_synch_price'] = GETPOST('product_synch_price', 'aZ09');
 	$object->parameters['product_weight_units'] = empty($conf->global->PRODUCT_DISABLE_WEIGHT) ? GETPOST('product_weight_units', 'int') : 0; // 0 = Kg
 	$object->parameters['product_dimension_units'] = empty($conf->global->PRODUCT_DISABLE_SIZE) ? GETPOST('product_dimension_units', 'int') : 2; // 2 = cm
-	$object->parameters['product_variation_mode'] = GETPOST('product_variation_mode', 'az09');
+	$object->parameters['product_variation_mode'] = GETPOST('product_variation_mode', 'aZ09');
     $object->parameters['enable_product_plugin_wpml_support'] = GETPOST('enable_product_plugin_wpml_support', 'int') ? 1 : 0;
 	$object->parameters['product_status_supported'] = GETPOST('product_status_supported', 'alphanohtml');
 
@@ -185,14 +185,14 @@ if ($action == 'set_options') {
 } elseif ($action == 'set_synchronize_sens_options') {
 	$object->oldcopy = clone $object;
 
-	$object->parameters['product_synch_direction']['ref'] = GETPOST('product_synch_direction_ref', 'az09');
-	$object->parameters['product_synch_direction']['description'] = GETPOST('product_synch_direction_description', 'az09');
-	$object->parameters['product_synch_direction']['short_description'] = GETPOST('product_synch_direction_short_description', 'az09');
-	$object->parameters['product_synch_direction']['weight'] = empty($conf->global->PRODUCT_DISABLE_WEIGHT) ? GETPOST('product_synch_direction_weight', 'az09') : 'etod';
-	$object->parameters['product_synch_direction']['dimension'] = empty($conf->global->PRODUCT_DISABLE_SIZE) ? GETPOST('product_synch_direction_dimension', 'az09') : 'etod';
-	$object->parameters['product_synch_direction']['tax'] = GETPOST('product_synch_direction_tax', 'az09');
-	$object->parameters['product_synch_direction']['status'] = GETPOST('product_synch_direction_status', 'az09');
-	$object->parameters['product_synch_direction']['image'] = GETPOST('product_synch_direction_image', 'az09');
+	$object->parameters['product_synch_direction']['ref'] = GETPOST('product_synch_direction_ref', 'aZ09');
+	$object->parameters['product_synch_direction']['description'] = GETPOST('product_synch_direction_description', 'aZ09');
+	$object->parameters['product_synch_direction']['short_description'] = GETPOST('product_synch_direction_short_description', 'aZ09');
+	$object->parameters['product_synch_direction']['weight'] = empty($conf->global->PRODUCT_DISABLE_WEIGHT) ? GETPOST('product_synch_direction_weight', 'aZ09') : 'etod';
+	$object->parameters['product_synch_direction']['dimension'] = empty($conf->global->PRODUCT_DISABLE_SIZE) ? GETPOST('product_synch_direction_dimension', 'aZ09') : 'etod';
+	$object->parameters['product_synch_direction']['tax'] = GETPOST('product_synch_direction_tax', 'aZ09');
+	$object->parameters['product_synch_direction']['status'] = GETPOST('product_synch_direction_status', 'aZ09');
+	$object->parameters['product_synch_direction']['image'] = GETPOST('product_synch_direction_image', 'aZ09');
 
 	$result = $object->update($user);
 

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -75,7 +75,7 @@ if ($action == 'set_options') {
 	$object->name = GETPOST('site_name', 'alphanohtml');
 	$object->api_version = GETPOST('site_api_version', 'alphanohtml');
 	$object->webservice_address = GETPOST('site_webservice_address', 'alphanohtml');
-	$object->authentication_type = GETPOST('site_authentication_type', 'az09');
+	$object->authentication_type = GETPOST('site_authentication_type', 'aZ09');
 	$object->user_name = GETPOST('site_user_name', 'alphanohtml');
 	$object->user_password = GETPOST('site_user_password', 'none');
 	$object->timeout = GETPOST('site_timeout', 'int');
@@ -233,7 +233,7 @@ if ($action == 'set_options') {
 } elseif ($action == 'set_wordpress_api_options' && $object->id > 0) {
 	$object->oldcopy = clone $object;
 
-	$object->wordpress_authentication_type = GETPOST('wordpress_authentication_type', 'az09');
+	$object->wordpress_authentication_type = GETPOST('wordpress_authentication_type', 'aZ09');
 	$object->wordpress_authentication_login = !empty($object->wordpress_authentication_type) ? GETPOST('wordpress_authentication_login', 'none') : '';
 	$object->wordpress_authentication_password = !empty($object->wordpress_authentication_type) ? GETPOST('wordpress_authentication_password', 'none') : '';
 	$object->wordpress_timeout = !empty($object->wordpress_authentication_type) ? GETPOST('wordpress_timeout', 'int') : 0;

--- a/admin/stock.php
+++ b/admin/stock.php
@@ -93,7 +93,7 @@ $movement_stock_on_validate_invoice = !empty($conf->global->STOCK_CALCULATE_ON_B
 if ($action == 'set_options') {
 	$object->oldcopy = clone $object;
 
-	$object->stock_sync_direction = GETPOST('stock_sync_direction', 'az09');
+	$object->stock_sync_direction = GETPOST('stock_sync_direction', 'aZ09');
 	$object->parameters['enable_warehouse_plugin_support'] = $object->stock_sync_direction != 'none' ? GETPOST('enable_warehouse_plugin_support', 'aZ09') : '';
 	if ($object->parameters['enable_warehouse_plugin_support'] == -1) $object->parameters['enable_warehouse_plugin_support'] = '';
 	$object->fk_warehouse = $object->stock_sync_direction == 'ecommerce2dolibarr' && empty($object->parameters['enable_warehouse_plugin_support']) ? GETPOST('fk_warehouse', 'int') : 0;


### PR DESCRIPTION
#### **Problems Addressed:**

1. The 'Authentication type' and 'Stock synchronization' field values were not being saved.
2. Some order/product metas failed to be sanitized, leading to the following log error:
   ```
   Error, you call sanitizeVal() with a bad value for the check type. Data will be sanitized with alphanohtml.
   ```

#### **Cause of the Issue:**

The root cause was the usage of the `GETPOST()` function with `'az09'` as the second argument. The correct argument should be `'aZ09'` (with an uppercase 'Z') for proper data handling.

#### **Changes Made:**

- Replaced all instances of `'az09'` with `'aZ09'` in `GETPOST()` function calls to ensure correct sanitization and field value saving.

#### **Files Modified:**
- `admin/order.php`
- `admin/product.php`
- `admin/setup.php`
- `admin/stock.php`

#### **Testing:**
- The changes have been tested with **Dolibarr 20.0.0** and **PHP 8.1**.
- Verified that fields now save correctly, and the log error has been resolved.
