### PR TITLE
Fix Ambiguous ‘rowid’ Column in Web Hooks List Query Count

### DIFF
--- a/webhookslist.php
+++ b/webhookslist.php
@@ -232,7 +232,7 @@ $parameters=array();
 $reshook=$hookmanager->executeHooks('printFieldListWhere', $parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
 
-$sql.= $db->order($sortfield . ", rowid", $sortorder . "," . $sortorder);
+$sql.= $db->order($sortfield . ", epw.rowid", $sortorder . "," . $sortorder);
 
 // Count total nb of records
 $nbtotalofrecords = '';


### PR DESCRIPTION
### PR Description:
This pull request addresses an issue where the **Web Hooks List** in Dolibarr was incorrectly showing 0 processed hooks due to an SQL error caused by ambiguity in the `rowid` column during sorting.

The error in the log:
```
2024-10-02 15:59:34 DEBUG   197.15.130.128  3759257   1001 sql=SELECT COUNT(*) AS nb  FROM llx_ecommerce_pending_webhooks AS epw LEFT JOIN llx_ecommerce_site AS es on es.rowid = epw.site_id WHERE es.entity IN (1) ORDER BY epw.status ASC, rowid ASC
2024-10-02 15:59:34 ERR     197.15.130.128  3759257   1001 DoliDBMysqli::query Exception in query instead of returning an error: Column 'rowid' in order clause is ambiguous
2024-10-02 15:59:34 ERR     197.15.130.128  3759257   1001 DoliDBMysqli::query SQL Error message: DB_ERROR_1052 Column 'rowid' in order clause is ambiguous From /hidden-path/htdocs/custom/ecommerceng/webhookslist.php:240.
```

The fix resolves this ambiguity by specifying the correct table for the `rowid` column in the query. As a result, the **Web Hooks List** now correctly displays the number of hooks instead of showing 0.